### PR TITLE
Adapt to API changes in lsp-mode

### DIFF
--- a/lsp-go.el
+++ b/lsp-go.el
@@ -12,10 +12,10 @@
 (require 'go-mode)
 
 ;;;###autoload
-(lsp-define-client 'go-mode "go" 'stdio #'(lambda () default-directory)
-  :command '("go-langserver" "-mode=stdio")
-  :name "Go Language Server"
-  :ignore-regexps '("^langserver-go: reading on stdin, writing on stdout$"))
+(lsp-define-stdio-client 'go-mode "go" 'stdio #'(lambda () default-directory)
+			 "Go Language Server"
+			 '("go-langserver" "-mode=stdio")
+			 :ignore-regexps '("^langserver-go: reading on stdin, writing on stdout$"))
 
 (provide 'lsp-go)
 ;;; lsp-go.el ends here


### PR DESCRIPTION
lsp-define-client was renamed to lsp-define-stdio-client and its
signature also changed slightly.
This should fix issue #1 