### PR TITLE
use new api

### DIFF
--- a/lsp-go.el
+++ b/lsp-go.el
@@ -8,14 +8,15 @@
 ;; Keywords: go, golang
 ;; URL: https://github.com/emacs-lsp/lsp-go
 
+;;; Code:
+
 (require 'lsp-mode)
 (require 'go-mode)
 
 ;;;###autoload
-(lsp-define-client 'go-mode "go" 'stdio #'(lambda () default-directory)
-  :command '("go-langserver" "-mode=stdio")
-  :name "Go Language Server"
-  :ignore-regexps '("^langserver-go: reading on stdin, writing on stdout$"))
+(lsp-define-stdio-client 'go-mode "go" 'stdio #'(lambda () default-directory) "Go Language Server"
+                         '("go-langserver" "-mode=stdio")
+                         :ignore-regexps '("^langserver-go: reading on stdin, writing on stdout$"))
 
 (provide 'lsp-go)
 ;;; lsp-go.el ends here


### PR DESCRIPTION
I can't try `lsp-go` without this changes. Looks like lsp-mode API was changed.