### PR TITLE
Enable autocompletion from go-langserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# lsp-go
+
 [![MELPA](https://melpa.org/packages/lsp-go-badge.svg)](https://melpa.org/#/lsp-go)
 
 Go support for `lsp-mode` using [Sourcegraph's Go Language Server](https://github.com/sourcegraph/go-langserver)
+
+## Configuration
+
+You will need to call `lsp-go-enable` when editing `.go` files. You can use the following in your Emacs init file:
+
+```lisp
+(add-hook 'go-mode-hook #'lsp-go-enable)
+```

--- a/lsp-go.el
+++ b/lsp-go.el
@@ -12,7 +12,7 @@
 
 ;;;###autoload
 (lsp-define-stdio-client lsp-go "go" #'(lambda () default-directory)
-			 '("go-langserver" "-mode=stdio")
+			 '("go-langserver" "-mode=stdio" "-gocodecompletion")
 			 :ignore-regexps
 			 '("^langserver-go: reading on stdin, writing on stdout$"))
 


### PR DESCRIPTION
There is [a flag for go-langserver](https://github.com/sourcegraph/go-langserver/blob/c0ef041f24a52e734b83c2f69075ad95df7ff97e/main.go#L32) that will enable autocompletion. I have tested this in my fork, and autocompletion works (via `company-capf` using [company-mode](http://company-mode.github.io/)).

I have also updated the README with an example of how to add a hook that will enable `lsp-go` when editing `.go` files.