### PR TITLE
Add custom variable for lsp server executable path

### DIFF
--- a/lsp-go.el
+++ b/lsp-go.el
@@ -16,6 +16,7 @@
 
 (defcustom lsp-go-executable-path (executable-find "go-langserver")
   "Path to the go-langserver executable."
+  :type 'string
   :group 'lsp-go)
 
 (lsp-define-stdio-client lsp-go "go" #'(lambda () default-directory)

--- a/lsp-go.el
+++ b/lsp-go.el
@@ -10,8 +10,16 @@
 
 (require 'lsp-mode)
 
+(defgroup lsp-go nil
+  "lsp-go settings"
+  :group 'tools)
+
+(defcustom lsp-go-executable-path (executable-find "go-langserver")
+  "Path to the go-langserver executable."
+  :group 'lsp-go)
+
 (lsp-define-stdio-client lsp-go "go" #'(lambda () default-directory)
-			 '("go-langserver" "-mode=stdio" "-gocodecompletion")
+			 `(,lsp-go-executable-path "-mode=stdio" "-gocodecompletion")
 			 :ignore-regexps
 			 '("^langserver-go: reading on stdin, writing on stdout$"))
 


### PR DESCRIPTION
When testing out new versions of `go-langserver`, it'd be nice to easily customise the executable path. This PR gives the option. The default value is the executable in PATH so this shouldn't require users to change their config.